### PR TITLE
Update gem dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['3.2.9', '3.3.9', '3.4.5']
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Ruby ${{ matrix.ruby-version }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
+
+    - name: Run tests
+      run: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.2.8
-  - 2.3.1
-  - 2.3.5
-  - 2.4.2
-before_install: gem install bundler -v 1.15.4
+  - 3.4.5
+  - 3.3.9
+  - 3.2.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 3.4.5
-  - 3.3.9
-  - 3.2.9

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SidekiqProcessKiller
 
-[![Build Status](https://travis-ci.org/shayonj/sidekiq_process_killer.svg?branch=master)](https://travis-ci.org/shayonj/sidekiq_process_killer)
+[![CI](https://github.com/shayonj/sidekiq_process_killer/workflows/CI/badge.svg)](https://github.com/shayonj/sidekiq_process_killer/actions)
 
 When you have memory leaks or "bloats" in your ruby application, identifying and fixing them can at times be a nightmare. Instead, an _"acceptable"_ mitigation is to re-spin the workers. Its a common technique that can be found in [Puma Worker Killer](https://github.com/schneems/puma_worker_killer) or [Unicorn Worker Killer](https://github.com/kzk/unicorn-worker-killer). Though, its neater and good practice to find and fix your leaks.
 

--- a/lib/sidekiq_process_killer/middleware.rb
+++ b/lib/sidekiq_process_killer/middleware.rb
@@ -11,7 +11,7 @@ module SidekiqProcessKiller
       @pid        = ::Process.pid
       @worker     = worker.class
       @queue      = queue
-      @memory     = process_memory.mb
+      @memory     = GetProcessMem.new.mb
       @jid        = job['jid']
 
       memory_threshold = SidekiqProcessKiller.memory_threshold
@@ -25,10 +25,6 @@ module SidekiqProcessKiller
         worker_name: worker.class,
         current_memory_usage: memory
       })
-    end
-
-    private def process_memory
-      @memory ||= GetProcessMem.new
     end
 
     private def humanized_attributes

--- a/lib/sidekiq_process_killer/version.rb
+++ b/lib/sidekiq_process_killer/version.rb
@@ -1,3 +1,3 @@
 module SidekiqProcessKiller
-  VERSION = "0.4.2"
+  VERSION = "0.5.0"
 end

--- a/sidekiq_process_killer.gemspec
+++ b/sidekiq_process_killer.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/shayonj/sidekiq_process_killer"
   spec.license       = "MIT"
 
-  spec.required_ruby_version  = ">= 2.2.2"
+  spec.required_ruby_version  = ">= 3.2.0"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})

--- a/sidekiq_process_killer.gemspec
+++ b/sidekiq_process_killer.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.15"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
 
   spec.add_dependency "get_process_mem", "~> 0.2.1"

--- a/sidekiq_process_killer.gemspec
+++ b/sidekiq_process_killer.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_dependency "get_process_mem", "~> 0.2.1"
+  spec.add_dependency "get_process_mem", "~> 1.0"
   spec.add_dependency "sidekiq", "~> 5"
 end


### PR DESCRIPTION
A tiny optimisation to remove some memoisation but the primary goal here was to use `get_process_mem` 1.x and update the Ruby versions we test against.